### PR TITLE
Refactor get-version

### DIFF
--- a/.github/workflows/check-commits.yml
+++ b/.github/workflows/check-commits.yml
@@ -16,7 +16,10 @@ jobs:
     - uses: FlowingCode/action-conventional-commits@master
     
     - name: Get version
-      run: echo "VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
+      run: |
+        V=$(grep "<version>" pom.xml | sed -E 's/.*<version>(.*)<\/version>.*/\1/' | sed -n '2p')
+        [ -z "$V" ] && V=$(grep "<version>" pom.xml | sed -E 's/.*<version>(.*)<\/version>.*/\1/' | sed -n '1p')
+        echo "VERSION=$(echo $V | xargs)" >> $GITHUB_ENV
     
     - name: Check snapshot version
       if: ${{ !endsWith( env.VERSION , '-SNAPSHOT' ) }}

--- a/.github/workflows/check-commits.yml
+++ b/.github/workflows/check-commits.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: FlowingCode/action-conventional-commits@master
     
     - name: Get version
-      run: echo "VERSION=$(grep -oPm1 "(?<=<version>)[^<]+" "pom.xml")" >> $GITHUB_ENV && cat $GITHUB_ENV | grep VERSION=
+      run: echo "VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
     
     - name: Check snapshot version
       if: ${{ !endsWith( env.VERSION , '-SNAPSHOT' ) }}


### PR DESCRIPTION
Instead of capturing the first occurrence of the <version> tag, which often points to the parent-pom in Maven architectures, it now identifies the project's specific version by targeting the second occurrence in the document hierarchy.

**Logic Breakdown:**

1. Tag Isolation: The `grep "<version>"` command scans the pom.xml and retrieves all lines containing versioning information, preserving their document order.
2. Stream Cleaning: Using `sed -E 's/.*<version>(.*)<\/version>.*/\1/'`, the script applies a Regular Expression to strip  XML tags and leading/trailing whitespace, isolating the raw version string (e.g., 1.1.0-SNAPSHOT).
3. Positional Selection: In a standard Maven POM with a parent, the first match is the Parent Version. The second match (`sed -n '2p'`) is the Project Artifact Version.
4. Conditional Fallback: The script includes a safety check: if no second line exists (indicating a standalone project without a parent), it defaults to the first match (`sed -n '1p'`).
5. Environment Integration: The resulting string is piped through `xargs` to ensure absolute character purity before being injected into the `$GITHUB_ENV` for downstream validation steps.

Close #2